### PR TITLE
Add build-container make target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: required
 before_install:
         - sudo add-apt-repository ppa:projectatomic/ppa --yes
         - sudo apt-get update -qq
-        - sudo apt-get install -qq shellcheck skopeo
+        - sudo apt-get install -qq podman shellcheck skopeo
 
 script:
         - make validate
+        - make build-container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM docker.io/library/fedora:latest
 
 RUN dnf install -y jq skopeo findutils file 'dnf-command(download)'
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 SRC := ./BuildSourceImage.sh
+CTR_IMAGE := localhost/containers/buildsourceimage
 
 all: validate
 
 .PHONY: validate
 validate: $(SRC)
 	shellcheck -a $(SRC)
+
+.PHONY: build-container
+build-container: Dockerfile
+	podman build -f Dockerfile -t $(CTR_IMAGE) .


### PR DESCRIPTION
To avoid regressing on the Dockerfile, run the new make target in the CI
as well.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>