### PR TITLE
*: clarify output directory written

### DIFF
--- a/BuildSourceImage.sh
+++ b/BuildSourceImage.sh
@@ -1096,6 +1096,7 @@ main() {
         _mkdir_p "${output_dir}"
         # XXX this $input_inspect_image_ref currently relies on the user passing in the `-i` flag
         push_img "oci:$src_img_dir:${src_img_tag}" "oci:$output_dir:$(ref_src_img_tag "$(parse_img_tag "${input_inspect_image_ref}")")"
+        _info "copied to oci:$output_dir:$(ref_src_img_tag "$(parse_img_tag "${input_inspect_image_ref}")")"
     fi
 
     if [ -n "${push_image_ref}" ] ; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,4 @@ RUN mkdir -p /output
 ENV OUTPUT_DIR=/output
 VOLUME /output
 
-ENV SRC_DIR=/src
-VOLUME /src
-
 ENTRYPOINT ["/usr/local/bin/BuildSourceImage.sh"]


### PR DESCRIPTION
Also, SRC_DIR is no longer used.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>