### PR TITLE
Enable non-root container

### DIFF
--- a/BuildSourceImage.sh
+++ b/BuildSourceImage.sh
@@ -976,6 +976,10 @@ main() {
         _rm_rf "${TMPDIR}"
     fi
     _mkdir_p "${TMPDIR}"
+    ret=$?
+    if [ ${ret} -ne 0 ] ; then
+        _error "failed to mkdir ${TMP}"
+    fi
 
     # setup rootfs to be inspected (if any)
     rootfs=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN mkdir -p /output
 ENV OUTPUT_DIR=/output
 VOLUME /output
 
-ENTRYPOINT ["/usr/local/bin/BuildSourceImage.sh"]
+ENTRYPOINT ["/usr/local/bin/BuildSourceImage.sh", "-b", "/tmp/"]

--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ Usage: BuildSourceImage.sh [-D] [-b <path>] [-c <path>] [-e <path>] [-r <path>] 
 
 ```
 
-It also nicely usable inside a container
+Nicely usable inside a container:
+
 ```bash
-$> buildah build-using-dockerfile -t containers/buildsourceimage .
+$> podman build -t containers/buildsourceimage .
+$> mkdir ./output/
+$> podman run -it -v $(pwd)/output/:/output/ -v $(pwd)/SRCRPMS/:/data/ -u $(id -u) containers/buildsourceimage -s /data/
 ```
 
 ## Examples
@@ -45,4 +48,3 @@ $> buildah build-using-dockerfile -t containers/buildsourceimage .
 * Build a source code image from a collection of known `.src.rpm`'s
 * Include additional build context into the source image
 * Include extra sources use
-


### PR DESCRIPTION
With this, it enables running as non-root inside the container. It will not default to this because the user may wish the UID of the files owned in the `/output` to match. (but we might could be fine to have a uid of 1000 or something as well, cause by default these output files will be owned by UID 0)