### PR TITLE
Makefile: no need to shell to realpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ cleanfiles += .testprep $(srpms)
 test-integration: .build-container .testprep
 	@echo
 	@echo "==> Running integration tests"
-	TMPDIR=$(shell realpath .testprep/tmp) bats $(BATS_OPTS) test/
+	TMPDIR=$(realpath .testprep/tmp) bats $(BATS_OPTS) test/
 
 
 clean:


### PR DESCRIPTION
Fixes #41

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>