### PR TITLE
BuildSourceImage: expose "unpack" as subcommand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ RUN dnf install -y jq skopeo findutils file 'dnf-command(download)'
 
 COPY ./BuildSourceImage.sh /usr/local/bin/BuildSourceImage.sh
 
-ENTRYPOINT ["/usr/local/bin/BuildSourceImage.sh", "-b", "/tmp/"]
+ENV BASE_DIR=/tmp
+
+ENTRYPOINT ["/usr/local/bin/BuildSourceImage.sh"]

--- a/test/02-from_image_ref.bats
+++ b/test/02-from_image_ref.bats
@@ -3,6 +3,7 @@
 load helpers
 
 @test "Build from image reference" {
+	#skip "this takes like 20min ..."
     local d
     d=$(mktemp -d)
     echo "temporary directory: ${d}"

--- a/test/03-unpack.bats
+++ b/test/03-unpack.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats -t
+
+load helpers
+
+@test "unpack - no args" {
+	run_ctr $CTR_IMAGE unpack
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} =~ "[SrcImg][ERROR] [unpack_img] blank arguments provided" ]]
+}
+
+@test "unpack - Help" {
+	run_ctr $CTR_IMAGE unpack -h
+	[ "$status" -eq 1 ]
+	[[ ${lines[0]} =~ "BuildSourceImage.sh unpack <oci layout path> <unpack path>" ]]
+}
+
+@test "unpack - from a SRPM build" {
+	local d
+	local r
+
+	d=$(mktemp -d)
+	echo "temporary directories: output - ${d}"
+	run_ctr -v $(pwd)/.testprep/srpms/:/src:ro --mount type=bind,source=${d},destination=/output $CTR_IMAGE -s /src -o /output
+	[ "$status" -eq 0 ]
+	[ -f "${d}/index.json" ]
+
+	r=$(mktemp -d)
+	echo "temporary directories: unpacked - ${r}"
+	run_ctr --mount type=bind,source=${d},destination=/output -v ${r}:/unpacked/ $CTR_IMAGE unpack /output/ /unpacked/
+	[ "$(find ${r} -type f | wc -l)" -eq 3 ] # regular files
+	[ "$(find ${r} -type l | wc -l)" -eq 3 ] # and symlinks
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,3 +1,8 @@
+#!/bin/bash
+
+export CTR_IMAGE="${CTR_IMAGE:-localhost/containers/buildsourceimage}"
+export CTR_ENGINE="${CTR_ENGINE:-podman}"
+
 function run_ctr() {
 	run $CTR_ENGINE run --security-opt label=disable --rm "$@"
 }


### PR DESCRIPTION
This may be a pattern we can do for some of the more useful functions.
But for now, folks can build, push, etc. and once they skopeo copy an
image to their host, they can

```bash
./BuildSourceImage unpack <src> <dest>
```

and it will be nicely exposed in the container build too

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>