### PR TITLE
Use extra-src archive checksum in filename

### DIFF
--- a/BuildSourceImage.sh
+++ b/BuildSourceImage.sh
@@ -1030,19 +1030,21 @@ sourcedriver_extra_src_dir() {
     local out_dir="${3}"
     local manifest_dir="${4}"
     local tarname
+    local tmptarname
     local mimetype
     local source_info
-    local counter=0
 
     for extra_src_dir in "${EXTRA_SRC_DIR_ARRAY[@]}"
     do
         _info "adding extra source directory $extra_src_dir"
         _debug "$self: writing to $out_dir and $manifest_dir"
-        tarname="extra-src-${counter}.tar"
-        ((counter+=1))
+        tmptarname="extra-src.tar"
         _tar -C "${extra_src_dir}" \
             --sort=name --mtime=@0 --owner=0 --group=0 --mode='a+rw' --no-xattrs --no-selinux --no-acls \
-            -cf "${out_dir}/${tarname}" .
+            -cf "${out_dir}/${tmptarname}" .
+        checksum=$(sha256sum "${out_dir}/${tmptarname}" | cut -d' ' -f1)
+        tarname="extra-src-${checksum}.tar"
+        mv "${out_dir}/${tmptarname}" "${out_dir}/${tarname}"
         mimetype="$(file --brief --mime-type "${out_dir}"/"${tarname}")"
         source_info="${manifest_dir}/${tarname}.json"
         jq \


### PR DESCRIPTION
This PR proposes a new extra-src file name form.

There is a use case for source container images with extra sources. That is, after deduplicating sources between two images then merge them, same extra source tar archive names remain potentially.

For instance, image A has extra-src-[012].tar archive per layer and image B has extra-src-[01].tar archive per layer. When extra-src-1.tar of image B duplicates the extra-src-2.tar of image A and is removed, then after merging these two images, the final source image will have two layers including extra-src-0.tar.

As a result, if users extract the sources sequentially, previous extra-src-*.tar file may be overwritten.

This patch replaces the counter with checksum computed from the extra source archive to avoid such potential duplicate. It is convenient for manipulate sources by image layers directly without the need of adjusting the counter.